### PR TITLE
Use reflect.DeepEqual to compare values

### DIFF
--- a/match.go
+++ b/match.go
@@ -72,7 +72,7 @@ func matchFilterQuery(a rel.FilterQuery, b rel.FilterQuery) bool {
 	default:
 		if a.Type != b.Type ||
 			a.Field != b.Field ||
-			(!reflect.DeepEqual(a.Value, b.Value) && !reflect.DeepEqual(a.Value, Any)) ||
+			(!reflect.DeepEqual(a.Value, b.Value) && a.Value != Any) ||
 			len(a.Inner) != len(b.Inner) {
 			return false
 		}

--- a/match_test.go
+++ b/match_test.go
@@ -4,8 +4,19 @@ import (
 	"testing"
 
 	"github.com/go-rel/rel"
+	"github.com/go-rel/rel/where"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestMatchFilterQuery_concrete_values(t *testing.T) {
+	assert.True(t, matchFilterQuery(where.InInt("id", []int{1}), where.InInt("id", []int{1})))
+	assert.True(t, matchFilterQuery(where.In("id", 1), where.InInt("id", []int{1})))
+	assert.True(t, matchFilterQuery(where.Eq("id", 1), where.Eq("id", 1)))
+	assert.False(t, matchFilterQuery(where.Eq("id", 1).And(where.Eq("title","book")), where.Eq("id", 1)))
+	assert.False(t, matchFilterQuery(where.InInt("id", []int{1}), where.Eq("id", 1)))
+	assert.False(t, matchFilterQuery(where.Eq("id", "1"), where.Eq("id", 1)))
+	assert.False(t, matchFilterQuery(where.Eq("id", "1"), where.Eq("title", "1")))
+}
 
 func TestMatchContains(t *testing.T) {
 	assert.True(t, matchContains(&Book{ID: 1}, &Book{ID: 1}))


### PR DESCRIPTION
we compare `a.Value` and `b.Value`, where there are possibilities that these values are actually equal slices, for example when we use `rel.In`. Is that OK if we use `reflect.DeepEqual` instead?