### PR TITLE
Pass matching mutators if unset

### DIFF
--- a/mutate.go
+++ b/mutate.go
@@ -27,7 +27,7 @@ func (m mutate) execute(name string, ctx context.Context, record interface{}, mu
 			(mm.argRecordType == "" || mm.argRecordType == reflect.TypeOf(record).String()) &&
 			(mm.argRecordTable == "" || mm.argRecordTable == rel.NewDocument(record, true).Table()) &&
 			(mm.argRecordContains == nil || matchContains(mm.argRecordContains, record)) &&
-			(len(mm.argMutators) == 0 || matchMutators(mm.argMutators, mutators)) &&
+			(mm.argMutators == nil || matchMutators(mm.argMutators, mutators)) &&
 			mm.assert.call(ctx) {
 			return mm.retError
 		}

--- a/mutate_test.go
+++ b/mutate_test.go
@@ -96,6 +96,11 @@ func TestMutate_Insert_set(t *testing.T) {
 		book   = Book{ID: 1, Title: "Rel for dummies"}
 	)
 
+	repo.ExpectInsert()
+	assert.Nil(t, repo.Insert(context.TODO(), &result, rel.Set("title", "Rel for dummies")))
+	assert.Equal(t, book, result)
+	repo.AssertExpectations(t)
+	
 	repo.ExpectInsert(rel.Set("title", "Rel for dummies"))
 	assert.Nil(t, repo.Insert(context.TODO(), &result, rel.Set("title", "Rel for dummies")))
 	assert.Equal(t, book, result)


### PR DESCRIPTION
On each 4 lines above it (`argRecord`, `argRecordType`, `argRecordTable`, and `argRecordContains`) a pass-if-unset condition is applied. Without such pre-check on `argMutators`, the test below will fail on `go-rel/reltest` while pass on `go-rel/rel/reltest`
```
func TestMutate_Insert_set(t *testing.T) {
	var (
		repo   = New()
		result Book
		book   = Book{ID: 1, Title: "Rel for dummies"}
	)

	repo.ExpectInsert()
	assert.Nil(t, repo.Insert(context.TODO(), &result, rel.Set("title", "Rel for dummies")))
	assert.Equal(t, book, result)
	repo.AssertExpectations(t)
}
```